### PR TITLE
Fix submodule info loading

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -195,6 +195,7 @@ func (c *Commit) GetSubModules() (*objectCache, error) {
 	}
 
 	scanner := bufio.NewScanner(rd)
+	c.submoduleCache = newObjectCache()
 	var ismodule bool
 	var path string
 	for scanner.Scan() {

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -36,7 +36,6 @@ func (repo *Repository) GetTagCommitID(name string) (string, error) {
 // \n\n separate headers from message
 func parseCommitData(data []byte) (*Commit, error) {
 	commit := new(Commit)
-	commit.submoduleCache = newObjectCache()
 	commit.parents = make([]sha1, 0, 1)
 	// we now have the contents of the commit object. Let's investigate...
 	nextline := 0

--- a/tree_entry.go
+++ b/tree_entry.go
@@ -144,7 +144,7 @@ func (tes Entries) GetCommitsInfo(commit *Commit, treePath string) ([][]interfac
 		go func(i int) {
 			cinfo := commitInfo{entryName: tes[i].Name()}
 			sm, err := commit.GetSubModule(path.Join(treePath, tes[i].Name()))
-			if err != nil {
+			if err != nil && !IsErrNotExist(err) {
 				cinfo.err = fmt.Errorf("GetSubModule (%s/%s): %v", treePath, tes[i].Name(), err)
 				revChan <- cinfo
 				return


### PR DESCRIPTION
* 1st commit - fixes regression causing no submodule info being loaded at all introduced in ebd9fb2
* 2nd commit - do not fail in GetCommitsInfo with no .gitmodules, causing 500 internal error in Gogs

See commit descriptions for more details.