### PR TITLE
Adding function to create a post-receive hook

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -115,13 +115,22 @@ func ListHooks(repoPath string) (_ []*Hook, err error) {
 }
 
 const (
-	HOOK_PATH_UPDATE = "hooks/update"
+	HOOK_PATH_UPDATE       = "hooks/update"
+	HOOK_PATH_POST_RECEIVE = "hooks/post-receive"
 )
 
 // SetUpdateHook writes given content to update hook of the reposiotry.
 func SetUpdateHook(repoPath, content string) error {
 	log("Setting update hook: %s", repoPath)
 	hookPath := path.Join(repoPath, HOOK_PATH_UPDATE)
+	os.MkdirAll(path.Dir(hookPath), os.ModePerm)
+	return ioutil.WriteFile(hookPath, []byte(content), 0777)
+}
+
+// SetPostReceive writes given content to the post-receive hook of the repository
+func SetPostReceiveHook(repoPath, content string) error {
+	log("Setting post-receive hook: %s", repoPath)
+	hookPath := path.Join(repoPath, HOOK_PATH_POST_RECEIVE)
 	os.MkdirAll(path.Dir(hookPath), os.ModePerm)
 	return ioutil.WriteFile(hookPath, []byte(content), 0777)
 }


### PR DESCRIPTION
This Pull Request enables a way to create a `post-receive` hook for a repository. This is needed for https://github.com/gogits/gogs/pull/2524