### PR TITLE
Fixed returning non empty tag list when there are no tags.

### DIFF
--- a/repo_tag.go
+++ b/repo_tag.go
@@ -103,7 +103,8 @@ func (repo *Repository) GetTags() ([]string, error) {
 		return nil, err
 	}
 
-	tags := strings.Split(strings.TrimSpace(stdout), "\n")
+	tags := strings.Split(stdout, "\n")
+	tags = tags[:len(tags)-1]
 
 	if version.Compare(gitVersion, "2.0.0", "<") {
 		version.Sort(tags)


### PR DESCRIPTION
Since #8, when a repo has no tags, then a non empty tag list is returned (`[""]`). Reference: gogits/gogs#2880

I made this mistake by replacing the previous implementation (`tags[:len(tags)-1]`) with `strings.TrimSpace(stdout)`. This worked fine, then there were tags, but created an invalid list otherwise.

This PR fixes this.

Sorry for my mistake!