### PR TITLE
Add support for abbreviated commit IDs

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -110,6 +110,13 @@ func (repo *Repository) getCommit(id sha1) (*Commit, error) {
 
 // GetCommit returns commit object of by ID string.
 func (repo *Repository) GetCommit(commitID string) (*Commit, error) {
+	if len(commitID) != 40 {
+		var err error
+		commitID, err = NewCommand("rev-parse", commitID).RunInDir(repo.Path)
+		if err != nil {
+			return nil, err
+		}
+	}
 	id, err := NewIDFromString(commitID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Support shorter commit IDs than 40 characters.
The default length of abbrev is 7 chars, and the absolute minimum is 4 chars. 
This is useful when the user only have the abbrev of a commit id.