### PR TITLE
Added functions to handle checking out branches and moving files

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -180,6 +180,10 @@ func (c *Commit) SearchCommits(keyword string) (*list.List, error) {
 	return c.repo.searchCommits(c.ID, keyword)
 }
 
+func (c *Commit) GetFilesChangedSinceCommit(pastCommit string) ([]string, error) {
+	return c.repo.getFilesChanged(pastCommit, c.ID.String())
+}
+
 func (c *Commit) GetSubModules() (*objectCache, error) {
 	if c.submoduleCache != nil {
 		return c.submoduleCache, nil

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -187,6 +187,14 @@ func (repo *Repository) searchCommits(id sha1, keyword string) (*list.List, erro
 	return repo.parsePrettyFormatLogToList(stdout)
 }
 
+func (repo *Repository) getFilesChanged(id1 string, id2 string) ([]string, error) {
+	stdout, err := NewCommand("diff", "--name-only", id1, id2).RunInDirBytes(repo.Path)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(stdout), "\n"), nil
+}
+
 func (repo *Repository) FileCommitsCount(revision, file string) (int64, error) {
 	return commitsCount(repo.Path, revision, file)
 }


### PR DESCRIPTION
This is needed for the PR #3092 on https://github.com/gogits/gogs/issues/1071 for editing files. What was needed was a way to set the branch when making a pull, checking out a branch, and moving a file with git mv. This is now all implemented.