### PR TITLE
Fixed incorrect relative submodule URLs

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -29,7 +29,7 @@ func NewSubModuleFile(c *Commit, refUrl, refId string) *SubModuleFile {
 
 // FIXME: remove import of setting
 // RefUrl guesses and returns reference URL.
-func (sf *SubModuleFile) RefUrl(urlPrefix string) string {
+func (sf *SubModuleFile) RefUrl(urlPrefix string, parentPath string) string {
 	if sf.refUrl == "" {
 		return ""
 	}
@@ -44,6 +44,14 @@ func (sf *SubModuleFile) RefUrl(urlPrefix string) string {
 	// http[s]://xxx/user/repo
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 		return url
+	}
+
+	// relative url prefix check (according to git submodule documentation)
+	if strings.HasPrefix(url, "./") || strings.HasPrefix(url, "../") {
+		// ...construct and return correct submodule url here...
+		idx := strings.LastIndex(parentPath, "/src/")
+		rel_url := strings.TrimSuffix(urlPrefix, "/") + parentPath[:idx] + "/" + url
+		return rel_url
 	}
 
 	// sysuser@xxx:user/repo


### PR DESCRIPTION
According to git submodule documentation base path for relative submodule URL
is parent repository's root - not submodule "mount point".

So it's necessary to know "path" of parent repository to create correct submodule
URL.

Unfortunately, RefUrl function semantics are changed (kind of API change), so it can break something else that uses it. 
At least it is required to change /templates/repo/view_list.tmpl in gogs project.

For more details see issue gogits/gogs#1926

Thus, maybe it's even better to make new function (temporary or permanently) similar to RefUrl (I don't know how bad it is to break compatibility in this particular case).