### PR TITLE
Avoid creating an array for the sole purpose of counting elements

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -142,7 +142,7 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 	}
 
 	if isFallback {
-		return int64(strings.Count(stdout, "\n")), nil
+		return int64(strings.Count(stdout, "\n")) + 1, nil
 	}
 	return strconv.ParseInt(strings.TrimSpace(stdout), 10, 64)
 }

--- a/commit.go
+++ b/commit.go
@@ -142,7 +142,7 @@ func commitsCount(repoPath, revision, relpath string) (int64, error) {
 	}
 
 	if isFallback {
-		return int64(len(strings.Split(stdout, "\n"))), nil
+		return int64(strings.Count(stdout, "\n")), nil
 	}
 	return strconv.ParseInt(strings.TrimSpace(stdout), 10, 64)
 }


### PR DESCRIPTION
Probably speeds up counting commits for git versions < 1.8.0,
although I dubt it would make a visible difference