### PR TITLE
Using env vars for commit author/email

### DIFF
--- a/command.go
+++ b/command.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 type Command struct {
 	name string
 	args []string
+	env  map[string]string
 }
 
 func (c *Command) String() string {
@@ -31,6 +33,7 @@ func NewCommand(args ...string) *Command {
 	return &Command{
 		name: "git",
 		args: args,
+		env: make(map[string]string),
 	}
 }
 
@@ -56,6 +59,13 @@ func (c *Command) RunInDirTimeoutPipeline(timeout time.Duration, dir string, std
 	}
 
 	cmd := exec.Command(c.name, c.args...)
+	if len(c.env) > 0 {
+		env := os.Environ()
+		for key,value := range c.env {
+			env = append(env, fmt.Sprintf("%s=%s", key,value))
+		}
+		cmd.Env = env
+	}
 	cmd.Dir = dir
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/commit.go
+++ b/commit.go
@@ -119,8 +119,8 @@ func CommitChanges(repoPath string, opts CommitChangesOptions) error {
 		if version.Compare(gitVersion, "1.7.1", ">") {
 			cmd.AddArguments("-c", "user.name="+opts.Committer.Name, "-c", "user.email="+opts.Committer.Email)
 		} else {
-			cmd.env["GIT_AUTHOR_EMAIL"] = opts.Committer.Name
-			cmd.env["GIT_AUTHOR_NAME"] = opts.Committer.Email
+			cmd.env["GIT_AUTHOR_EMAIL"] = opts.Committer.Email
+			cmd.env["GIT_AUTHOR_NAME"] = opts.Committer.Name
 		}
 	}
 	cmd.AddArguments("commit")

--- a/commit.go
+++ b/commit.go
@@ -116,7 +116,12 @@ type CommitChangesOptions struct {
 func CommitChanges(repoPath string, opts CommitChangesOptions) error {
 	cmd := NewCommand()
 	if opts.Committer != nil {
-		cmd.AddArguments("-c", "user.name="+opts.Committer.Name, "-c", "user.email="+opts.Committer.Email)
+		if version.Compare(gitVersion, "1.7.1", ">") {
+			cmd.AddArguments("-c", "user.name="+opts.Committer.Name, "-c", "user.email="+opts.Committer.Email)
+		} else {
+			cmd.env["GIT_AUTHOR_EMAIL"] = opts.Committer.Name
+			cmd.env["GIT_AUTHOR_NAME"] = opts.Committer.Email
+		}
 	}
 	cmd.AddArguments("commit")
 


### PR DESCRIPTION
This will allow Git versions under 1.7.2 to set Git author/email for commits.
