### PR TITLE
Fix count-objects InPack incorrectly multiplied by 1024

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -262,7 +262,7 @@ func GetRepoSize(repoPath string) (*CountObject, error) {
 		case strings.HasPrefix(line, _STAT_SIZE):
 			countObject.Size = com.StrTo(line[6:]).MustInt64() * 1024
 		case strings.HasPrefix(line, _STAT_IN_PACK):
-			countObject.InPack = com.StrTo(line[9:]).MustInt64() * 1024
+			countObject.InPack = com.StrTo(line[9:]).MustInt64()
 		case strings.HasPrefix(line, _STAT_PACKS):
 			countObject.Packs = com.StrTo(line[7:]).MustInt64()
 		case strings.HasPrefix(line, _STAT_SIZE_PACK):


### PR DESCRIPTION
According to https://git-scm.com/docs/git-count-objects only 'size', 'size-pack' and, 'size-garbage' are reported in KiB. 'in-pack' is just a number.