### PR TITLE
Fix issue with object IDs resulting in an exception

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -104,7 +104,7 @@ func (repo *Repository) getCommit(id sha1) (*Commit, error) {
 		return c.(*Commit), nil
 	}
 
-	data, err := NewCommand("cat-file", "-p", id.String()).RunInDirBytes(repo.Path)
+	data, err := NewCommand("cat-file", "commit", id.String()).RunInDirBytes(repo.Path)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 128") {
 			return nil, ErrNotExist{id.String(), ""}


### PR DESCRIPTION
## Fix for issue: 

https://github.com/gogits/gogs/issues/4855

## Problem statement:

The Repository#getCommit method's call to `git cat-file` succeeds if the `<object>` argument is a object reference, regardless of object type. If the `id` parameter of a blob is passed to the method, the command will run without an error and `parseCommitData` will panic when attempting to parse the blob data. 

## Proposed solution 

Restrict Repository#getCommit method call to `git cat-file` to only succeed if the `<object>` argument is a commit object reference by replacing the `-p` flag with a `<type>` argument with value `commit`. 

This makes it such that if the object reference is valid but not a commit, e.g. a blob, the command will return a non-zero exit status and the method will return an error instead of panicking when attempting to parse the data.

## Concerns

`-p`flag (pretty-print) does not seem to affect the output of commits for `cat-file`, but it is not compatible with `<type>` argument so I replaced it. Are there use-cases for the pretty-print flag?